### PR TITLE
Django 1.9+ Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 *.egg-info
 build/
 *.pyc
+.idea

--- a/private_media/urls.py
+++ b/private_media/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.conf import settings
 
 urlpatterns = [

--- a/private_media/urls.py
+++ b/private_media/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 from django.conf import settings
 
+from views import serve_private_file
+
 urlpatterns = [
     url(r'^{0}(?P<path>.*)$'.format(settings.PRIVATE_MEDIA_URL.lstrip('/')), serve_private_file)
 ]


### PR DESCRIPTION
Django 1.9+ dropped the 'pattern' class, hence I had to remove it for it work as it was still imported even though not in used. Also, there was an import error with the view. Now it's working fine on Django 1.10 :)
